### PR TITLE
Integrate API client

### DIFF
--- a/flow-typed/axios.js
+++ b/flow-typed/axios.js
@@ -1,0 +1,144 @@
+export interface AxiosTransformer {
+  (data: any, headers?: any): any;
+}
+
+export interface AxiosBasicCredentials {
+  username: string;
+  password: string;
+}
+
+export interface AxiosProxyConfig {
+  host: string;
+  port: number;
+  auth?: {
+    username: string,
+    password: string,
+  };
+  protocol?: string;
+}
+
+export type Method =
+  | 'get'
+  | 'GET'
+  | 'delete'
+  | 'DELETE'
+  | 'head'
+  | 'HEAD'
+  | 'options'
+  | 'OPTIONS'
+  | 'post'
+  | 'POST'
+  | 'put'
+  | 'PUT'
+  | 'patch'
+  | 'PATCH';
+
+export type ResponseType =
+  | 'arraybuffer'
+  | 'blob'
+  | 'document'
+  | 'json'
+  | 'text'
+  | 'stream';
+
+export interface Canceler {
+  (message?: string): void;
+}
+
+export interface Cancel {
+  message: string;
+}
+
+export interface CancelStatic {
+  new(message?: string): Cancel;
+}
+
+export interface CancelToken {
+  promise: Promise<Cancel>;
+  reason?: Cancel;
+  throwIfRequested(): void;
+}
+
+export interface CancelTokenSource {
+  token: CancelToken;
+  cancel: Canceler;
+}
+
+export interface CancelTokenStatic {
+  new(executor: (cancel: Canceler) => void): CancelToken;
+  source(): CancelTokenSource;
+}
+
+export interface AxiosInterceptorManager<V> {
+  use(
+    onFulfilled?: (value: V) => V | Promise<V>,
+    onRejected?: (error: any) => any,
+  ): number;
+  eject(id: number): void;
+}
+
+export interface AxiosRequestConfig {
+  url?: string;
+  method?: Method;
+  baseURL?: string;
+  transformRequest?: AxiosTransformer | AxiosTransformer[];
+  transformResponse?: AxiosTransformer | AxiosTransformer[];
+  headers?: any;
+  params?: any;
+  paramsSerializer?: (params: any) => string;
+  data?: any;
+  timeout?: number;
+  withCredentials?: boolean;
+  adapter?: AxiosAdapter;
+  auth?: AxiosBasicCredentials;
+  responseType?: ResponseType;
+  xsrfCookieName?: string;
+  xsrfHeaderName?: string;
+  onUploadProgress?: (progressEvent: any) => void;
+  onDownloadProgress?: (progressEvent: any) => void;
+  maxContentLength?: number;
+  validateStatus?: (status: number) => boolean;
+  maxRedirects?: number;
+  socketPath?: string | null;
+  httpAgent?: any;
+  httpsAgent?: any;
+  proxy?: AxiosProxyConfig | false;
+  cancelToken?: CancelToken;
+}
+
+export interface AxiosResponse<T = any> {
+  data: T;
+  status: number;
+  statusText: string;
+  headers: any;
+  config: AxiosRequestConfig;
+  request?: any;
+}
+
+export interface AxiosError extends Error {
+  config: AxiosRequestConfig;
+  code?: string;
+  request?: any;
+  response?: AxiosResponse;
+  isAxiosError: boolean;
+}
+
+export interface AxiosPromise<T = any> extends Promise<AxiosResponse<T>> {}
+
+export interface AxiosInstance {
+  (config: AxiosRequestConfig): AxiosPromise;
+  (url: string, config?: AxiosRequestConfig): AxiosPromise;
+  defaults: AxiosRequestConfig;
+  interceptors: {
+    request: AxiosInterceptorManager<AxiosRequestConfig>,
+    response: AxiosInterceptorManager<AxiosResponse>,
+  };
+  getUri(config?: AxiosRequestConfig): string;
+  request(config: AxiosRequestConfig): Promise<R>;
+  get(url: string, config?: AxiosRequestConfig): Promise<R>;
+  delete(url: string, config?: AxiosRequestConfig): Promise<R>;
+  head(url: string, config?: AxiosRequestConfig): Promise<R>;
+  post(url: string, data?: any, config?: AxiosRequestConfig): Promise<R>;
+  put(url: string, data?: any, config?: AxiosRequestConfig): Promise<R>;
+  patch(url: string, data?: any, config?: AxiosRequestConfig): Promise<R>;
+}

--- a/src/api/client.js
+++ b/src/api/client.js
@@ -1,0 +1,53 @@
+// @flow
+import axios from 'axios';
+
+const URL = process.env.REACT_APP_BASE_URL
+  ? `http://${process.env.REACT_APP_BASE_URL}:5000/api`
+  : 'http://localhost:5000/api';
+
+const getClient = (baseURL = URL) => {
+  console.log(baseURL);
+  const options = {
+    baseURL,
+  };
+
+  const client = axios.create(options);
+
+  return client;
+};
+
+class APIClient {
+  constructor(baseURL = null) {
+    this.client = getClient(baseURL);
+  }
+
+  delete(url, conf = {}) {
+    return this.client
+      .delete(url, conf)
+      .then(response => Promise.resolve(response))
+      .catch(error => Promise.reject(error));
+  }
+
+  get(url, conf = {}) {
+    return this.client
+      .get(url, conf)
+      .then(response => Promise.resolve(response))
+      .catch(error => Promise.reject(error));
+  }
+
+  post(url, data = {}, conf = {}) {
+    return this.client
+      .post(url, data, conf)
+      .then(response => Promise.resolve(response))
+      .catch(error => Promise.reject(error));
+  }
+
+  put(url, data = {}, conf = {}) {
+    return this.client
+      .put(url, data, conf)
+      .then(response => Promise.resolve(response))
+      .catch(error => Promise.reject(error));
+  }
+}
+
+export { APIClient };

--- a/src/api/client.js
+++ b/src/api/client.js
@@ -5,43 +5,45 @@ const URL = process.env.REACT_APP_BASE_URL
   ? `http://${process.env.REACT_APP_BASE_URL}:5000/api`
   : 'http://localhost:5000/api';
 
-const getClient = (baseURL = URL) => {
+const getClient = (baseURL: string = URL) => {
   const options = {
     baseURL,
   };
 
-  const client = axios.create(options);
+  const client: AxiosInstance = axios.create(options);
 
   return client;
 };
 
 class APIClient {
-  constructor(baseURL = URL) {
+  client: AxiosInstance;
+
+  constructor(baseURL: string = URL) {
     this.client = getClient(baseURL);
   }
 
-  delete(url, conf = {}) {
+  delete(url: string, conf: Object = {}) {
     return this.client
       .delete(url, conf)
       .then(response => Promise.resolve(response))
       .catch(error => Promise.reject(error));
   }
 
-  get(url, conf = {}) {
+  get(url: string, conf: Object = {}) {
     return this.client
       .get(url, conf)
       .then(response => Promise.resolve(response))
       .catch(error => Promise.reject(error));
   }
 
-  post(url, data = {}, conf = {}) {
+  post(url: string, data: Object = {}, conf: Object = {}) {
     return this.client
       .post(url, data, conf)
       .then(response => Promise.resolve(response))
       .catch(error => Promise.reject(error));
   }
 
-  put(url, data = {}, conf = {}) {
+  put(url: string, data: Object = {}, conf: Object = {}) {
     return this.client
       .put(url, data, conf)
       .then(response => Promise.resolve(response))

--- a/src/api/client.js
+++ b/src/api/client.js
@@ -6,7 +6,6 @@ const URL = process.env.REACT_APP_BASE_URL
   : 'http://localhost:5000/api';
 
 const getClient = (baseURL = URL) => {
-  console.log(baseURL);
   const options = {
     baseURL,
   };
@@ -17,7 +16,7 @@ const getClient = (baseURL = URL) => {
 };
 
 class APIClient {
-  constructor(baseURL = null) {
+  constructor(baseURL = URL) {
     this.client = getClient(baseURL);
   }
 


### PR DESCRIPTION
Now instead of directly making `axios` calls, we can use the `APIClient` to build a more robust REST client.